### PR TITLE
#45 wyjąć mesh z Redux store'a

### DIFF
--- a/src/components/Appointment/AppointmentDetails.tsx
+++ b/src/components/Appointment/AppointmentDetails.tsx
@@ -1,13 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
+import fs from "fs";
 import { useDispatch, useSelector } from "react-redux";
 import { Button, Dropdown, Header, Icon, Segment } from "semantic-ui-react";
 import { getCurrentAppointment, getCurrentPatient } from "../../redux/reducers";
-import { details, edit, navigate } from "../../redux/actions";
+import { details, edit, navigate, createRequest } from "../../redux/actions";
 
 const AppointmentDetails: React.FunctionComponent<{}> = () => {
   const patient = useSelector(getCurrentPatient);
   const appointment = useSelector(getCurrentAppointment);
   const dispatch = useDispatch();
+  const [busy, setBusy] = useState(false);
 
   if (!patient || !appointment) {
     return null;
@@ -16,7 +18,27 @@ const AppointmentDetails: React.FunctionComponent<{}> = () => {
   return (
     <>
       <Button.Group floated="right">
-        <Button primary onClick={() => dispatch(navigate("ADD_APPOINTMENT"))}>
+        <Button
+          disabled={busy}
+          primary
+          onClick={() => {
+            setBusy(true);
+            fs.readFile(
+              "./src/models/dolphins.ply",
+              async (err: any, data: { buffer: any }) => {
+                dispatch(
+                  createRequest("scans", {
+                    order: 7,
+                    appointmentId: appointment._id,
+                    patientId: patient._id,
+                    mesh: data.buffer
+                  } as any)
+                );
+                setBusy(false);
+              }
+            );
+          }}
+        >
           <Icon name="video camera" />
           Nowe badanie
         </Button>

--- a/src/components/MeshViewer/PLYModelView.tsx
+++ b/src/components/MeshViewer/PLYModelView.tsx
@@ -1,30 +1,24 @@
-import React from "react";
-import fs from "fs";
+import React, { useState, useEffect } from "react";
 import MeshViewer from "./MeshViewer";
-// import sizeof from "object-sizeof";
+import PouchDb from "pouchdb";
 
-class PLYModelView extends React.Component<{}, { data: any }> {
-  state = {
-    data: null
-  };
-
-  constructor(props: Readonly<{}>) {
-    super(props);
-    this.handleLoadModel = this.handleLoadModel.bind(this);
-  }
-
-  componentDidMount() {
-    fs.readFile("./src/models/model.ply", this.handleLoadModel);
-  }
-
-  handleLoadModel(err: any, data: { buffer: any }) {
-    this.setState({ data: data.buffer });
-    // console.log("Loaded PLY data model with size: " + sizeof(data));
-  }
-
-  render() {
-    return <MeshViewer data={this.state.data} />;
-  }
+interface PLYModelViewProps {
+  scanId: string;
 }
+
+const PLYModelView: React.FunctionComponent<PLYModelViewProps> = ({
+  scanId
+}) => {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const db = new PouchDb("scans");
+      const blob = (await db.getAttachment(scanId, "scan.ply")) as any;
+      setData((await new Response(blob).arrayBuffer()) as any);
+    })();
+  }, [scanId]);
+  return <MeshViewer data={data} />;
+};
 
 export default PLYModelView;

--- a/src/components/Patient/PatientDetails.tsx
+++ b/src/components/Patient/PatientDetails.tsx
@@ -91,7 +91,7 @@ const PatientDetails: React.FunctionComponent<{}> = () => {
           <Grid.Column width={9} style={{ padding: "0 0 3em 2em" }}>
             <Header as="h4">Ostatnie badanie - 02.02.2017, 09:00</Header>
             <Segment>
-              <PLYModelView />
+              <PLYModelView scanId="999" />
             </Segment>
           </Grid.Column>
         </Grid.Row>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,8 @@ import reducer from "./redux/reducers";
 import database from "./redux/middlewares/database";
 import flash from "./redux/middlewares/flash";
 import settings from "./redux/middlewares/settings";
+import logger from "./redux/middlewares/logger";
+
 import "moment/locale/pl";
 
 declare global {
@@ -21,7 +23,7 @@ declare global {
 const initialState = {};
 // eslint-disable-next-line no-undef
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const middlewares = [database, flash, settings];
+const middlewares = [logger, database, flash, settings];
 if (process.env.NODE_ENV !== "production") {
   // eslint-disable-next-line global-require
   middlewares.push(require("redux-immutable-state-invariant").default());

--- a/src/redux/middlewares/logger.ts
+++ b/src/redux/middlewares/logger.ts
@@ -1,0 +1,12 @@
+const logger: any = (store: any) => (next: any) => (action: any) => {
+    console.group(action.type)
+    const oldState = store.getState()
+    console.log('current state', oldState)
+    console.info(`dispatching`, action)
+    let result = next(action)
+    const newState = store.getState()
+    console.log('next state', newState)
+    console.groupEnd()
+    return result
+}
+export default logger

--- a/src/redux/reducers/current.ts
+++ b/src/redux/reducers/current.ts
@@ -29,7 +29,7 @@ const current = createReducer<ICurrent, IAction>(initCurrent)
       case 'ADD_APPOINTMENT':
         return { ...state, appointments: undefined };
       default:
-        return { ...state };
+        return state;
     }
   })
   .handleAction(edit, (state, action) => ({

--- a/src/redux/reducers/data.ts
+++ b/src/redux/reducers/data.ts
@@ -44,7 +44,7 @@ export type IResource = IPatient | IAppointment | IScan;
 
 export type INewPatient = Omit<IPatient, '_id' | '_rev'>;
 export type INewAppointment = Omit<IAppointment, '_id' | '_rev'>;
-type INewScan = Omit<IScan, '_id' | '_rev'>;
+export type INewScan = Omit<IScan, '_id' | '_rev'>;
 
 export type INewResource = INewPatient | INewAppointment | INewScan;
 


### PR DESCRIPTION
zmiana middleware'a i reducerów, aby pole scans.mesh trafiało bezpośrednio do poucha, a nie do Redux store'a
przykład, jak doczytać skan
przykład, jak zapisać stan
