### PR TITLE
Integrating PhysioLib with PhysioClient as a NPM module (#63)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third-party/PhysioProto"]
 	path = third-party/PhysioProto
 	url = https://github.com/quepas/PhysioProto.git
+[submodule "third-party/PhysioLibNativeAddon"]
+	path = third-party/PhysioLibNativeAddon
+	url = https://github.com/quepas/PhysioLibNativeAddon.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -11950,6 +11950,9 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "physio-lib": {
+      "version": "file:third-party/PhysioLibNativeAddon/addon"
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react": "^7.13.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
+    "physio-lib": "file:./third-party/PhysioLibNativeAddon/addon",
     "pouchdb": "^7.1.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/components/Appointment/AppointmentDetails.tsx
+++ b/src/components/Appointment/AppointmentDetails.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../redux/actions";
 import Scanner from "../../lib/scanner";
 import ScanList from "../Scan/ScanList";
+const PhysioLib = require("physio-lib");
 
 const AppointmentDetails: React.FunctionComponent<{}> = () => {
   const patient = useSelector(getCurrentPatient);
@@ -48,6 +49,8 @@ const AppointmentDetails: React.FunctionComponent<{}> = () => {
             scanner.scan((error: any, data: any) => {
               // TODO: Hide progressbar here
               setBusy(false);
+              console.log("Using PhysioLib " + PhysioLib.version());
+              let mirrored_mesh = PhysioLib.mirror(Buffer.from(data));
               dispatch(
                 createRequest("scans", {
                   comment: "",


### PR DESCRIPTION
Testowane na linux/windows. Z plusów udało się zachować podział na PhysioLibNativeAddon, który jest zewnętrznym modułem gitowym i który to przechowuje binarki, które będę dostarczać.

W przyszłości dopiszę typy TS dla PhysioLibNativeAddon więc będziemy mogli importwać przez `import`.
