### PR TITLE
Integration with PhysioLibWASM addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third-party/PhysioProto"]
 	path = third-party/PhysioProto
 	url = https://github.com/quepas/PhysioProto.git
+[submodule "third-party/PhysioLibWASM"]
+	path = third-party/PhysioLibWASM
+	url = https://github.com/quepas/PhysioLibWASM.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -11950,6 +11950,9 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "physio-lib": {
+      "version": "file:third-party/PhysioLibWASM/addon"
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react": "^7.13.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
+    "physio-lib": "file:./third-party/PhysioLibWASM/addon",
     "pouchdb": "^7.1.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/components/Appointment/AppointmentDetails.tsx
+++ b/src/components/Appointment/AppointmentDetails.tsx
@@ -17,6 +17,8 @@ import {
 } from "../../redux/actions";
 import Scanner from "../../lib/scanner";
 import ScanList from "../Scan/ScanList";
+// @ts-ignore
+import PhysioLib from "physio-lib";
 
 const AppointmentDetails: React.FunctionComponent<{}> = () => {
   const patient = useSelector(getCurrentPatient);
@@ -48,6 +50,19 @@ const AppointmentDetails: React.FunctionComponent<{}> = () => {
             scanner.scan((error: any, data: any) => {
               // TODO: Hide progressbar here
               setBusy(false);
+              // @ts-ignore
+              PhysioLib.then(Module => {
+                console.log(
+                  "Loaded PhysioLibWASM: " +
+                    Module.version() +
+                    " (inside PhysioLib: " +
+                    Module.physioLibVersion() +
+                    ")"
+                );
+                /* uncomment to perform symmetry analysis!
+                let mesh = Module.mirror(Buffer.from(data));
+                console.log('Mirror mesh size=' + mesh.length); */
+              });
               dispatch(
                 createRequest("scans", {
                   comment: "",


### PR DESCRIPTION
Ten sposób integracji nie jest idealny, ponieważ w paczce PhysioLibWASM jest ustawiona relatywna ścieżka dla tego projektu (`./third-party/PhysioLibWASM/addon`). A ścieżka ta jest potrzebna, ponieważ, gdy dodajemy do naszego projektu lokalną paczkę (poprzez `"file:./...` w `package.json`) to `npm install` robi tylko symbolic link do plików z paczki (zamiast ich faktycznie przenosić do `node_modules`). Zresztą, nawet jakby przenosił je, to i tak trzeba dokonfigurować webpacka tak, aby wrzucał do bundle'a pliki `*.wasm`. Nie udało mi się tego zrobić bez `ejecta` :p

Drugie podejście było z przeniesieniem pliku `physio-lib-wasm.wasm` i `physio-lib-wasm.js` bezpośrednio do `src/` naszego projektu. Wtedy niestety jest za dużo problemów z TS mam. 

Myślę, że na chwilę obecną ten sposób integracji jest wystarczający :)